### PR TITLE
Add media browsing functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ entity: browser
 
 `entity` is optional and defaults to `browser`.
 
-The card renders the same folders and media items that you normally see in the Media panel. Because the card uses the built-in Media Browser components, all navigation and playback features work as expected. The surrounding `ha-card` respects your active theme, so it fits nicely when using the Mushroom theme.
+The card loads media items from your configured media sources and displays them inside an `ha-card`. Folders can be opened by clicking on them and playable items will trigger the `media_player.play_media` service when selected. The surrounding `ha-card` respects your active theme, so it fits nicely when using the Mushroom theme.

--- a/media-browser-card.js
+++ b/media-browser-card.js
@@ -2,42 +2,110 @@ class MediaBrowserCard extends HTMLElement {
   constructor() {
     super();
     this.attachShadow({ mode: "open" });
+    this._path = [];
   }
 
   setConfig(config) {
     this._config = config || {};
     this._title = this._config.title || "Media Browser";
     this._entity = this._config.entity || "browser";
-    this.render();
+    this._renderBase();
   }
 
   set hass(hass) {
     this._hass = hass;
-    if (this._browser) {
-      this._browser.hass = hass;
+    if (this.isConnected) {
+      this._fetch();
     }
   }
 
-  render() {
+  connectedCallback() {
+    if (this._hass && !this._list) {
+      this._fetch();
+    }
+  }
+
+  _renderBase() {
     if (!this.shadowRoot) return;
     const style = document.createElement("style");
     style.textContent = `
       ha-card {
         padding: 0;
       }
+      .item {
+        padding: 8px;
+        cursor: pointer;
+      }
+      .item:hover {
+        background: var(--secondary-background-color);
+      }
+      .back {
+        padding: 8px;
+        cursor: pointer;
+        font-weight: bold;
+      }
     `;
     this.shadowRoot.innerHTML = `
       <ha-card header="${this._title}">
-        <ha-media-player-browse></ha-media-player-browse>
+        <div class="back" hidden id="back">⬅ Back</div>
+        <div id="list"></div>
       </ha-card>
     `;
     this.shadowRoot.appendChild(style);
-    this._browser = this.shadowRoot.querySelector("ha-media-player-browse");
-    if (this._browser) {
-      this._browser.hass = this._hass;
-      if (this._entity) {
-        this._browser.entityId = this._entity;
+    this._list = this.shadowRoot.getElementById("list");
+    this._back = this.shadowRoot.getElementById("back");
+    this._back.addEventListener("click", () => this._navigateBack());
+  }
+
+  async _fetch(mediaId) {
+    if (!this._hass) return;
+    const data = await this._hass.callWS({
+      type:
+        this._entity === "browser"
+          ? "media_source/browse_media"
+          : "media_player/browse_media",
+      entity_id: this._entity === "browser" ? undefined : this._entity,
+      media_content_id: mediaId,
+    });
+    this._current = data;
+    this._renderItems(data.children || []);
+    if (this._path.length > 0) {
+      this._back.removeAttribute("hidden");
+    } else {
+      this._back.setAttribute("hidden", "");
+    }
+  }
+
+  _renderItems(items) {
+    this._list.innerHTML = "";
+    for (const item of items) {
+      const div = document.createElement("div");
+      div.className = "item";
+      div.textContent = item.title;
+      div.addEventListener("click", () => {
+        if (item.can_expand) {
+          this._path.push(this._current);
+          this._fetch(item.media_content_id);
+        } else if (item.can_play && this._entity !== "browser") {
+          this._hass.callService("media_player", "play_media", {
+            entity_id: this._entity,
+            media_content_id: item.media_content_id,
+            media_content_type: item.media_content_type,
+          });
+        }
+      });
+      this._list.appendChild(div);
+    }
+  }
+
+  _navigateBack() {
+    const prev = this._path.pop();
+    if (prev) {
+      this._renderItems(prev.children || []);
+      if (this._path.length === 0) {
+        this._back.setAttribute("hidden", "");
       }
+      this._current = prev;
     }
   }
 


### PR DESCRIPTION
## Summary
- implement simple media fetching in `media-browser-card.js`
- update README to explain card behavior

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688508c489cc832e89ceca7042cf7124