### PR TITLE
Fix media card auto refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,5 @@ items will trigger the `media_player.play_media` service when selected. From
 version 1.1 on the card correctly includes `media_content_type` when opening
 folders so navigation into subdirectories works reliably. The surrounding
 `ha-card` respects your active theme, so it fits nicely when using the Mushroom
-theme.
+theme. The card will no longer refresh automatically on state updates. Use the
+new refresh button in the card header to manually reload the current folder.

--- a/media-browser-card.js
+++ b/media-browser-card.js
@@ -14,7 +14,7 @@ class MediaBrowserCard extends HTMLElement {
 
   set hass(hass) {
     this._hass = hass;
-    if (this.isConnected) {
+    if (this.isConnected && !this._current) {
       this._fetch();
     }
   }
@@ -32,6 +32,10 @@ class MediaBrowserCard extends HTMLElement {
       ha-card {
         padding: 0;
       }
+      .controls {
+        display: flex;
+        align-items: center;
+      }
       .item {
         padding: 8px;
         cursor: pointer;
@@ -44,17 +48,32 @@ class MediaBrowserCard extends HTMLElement {
         cursor: pointer;
         font-weight: bold;
       }
+      .refresh {
+        margin-left: auto;
+        padding: 8px;
+        cursor: pointer;
+      }
     `;
     this.shadowRoot.innerHTML = `
       <ha-card header="${this._title}">
-        <div class="back" hidden id="back">⬅ Back</div>
+        <div class="controls">
+          <div class="back" hidden id="back">⬅ Back</div>
+          <div class="refresh" id="refresh">⟳ Refresh</div>
+        </div>
         <div id="list"></div>
       </ha-card>
     `;
     this.shadowRoot.appendChild(style);
     this._list = this.shadowRoot.getElementById("list");
     this._back = this.shadowRoot.getElementById("back");
+    this._refresh = this.shadowRoot.getElementById("refresh");
     this._back.addEventListener("click", () => this._navigateBack());
+    this._refresh.addEventListener("click", () =>
+      this._fetch(
+        this._current?.media_content_id,
+        this._current?.media_content_type
+      )
+    );
   }
 
   async _fetch(mediaId, mediaType) {


### PR DESCRIPTION
## Summary
- stop automatic refresh when HA state updates
- add a refresh button to reload media
- document new refresh button

## Testing
- `node -v`
- `npm -v`


------
https://chatgpt.com/codex/tasks/task_e_68850c28e450832eb2eb1289d8ba481d