### PR TITLE
Enable UI configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ resources:
     type: module
 ```
 
+## Adding via the Lovelace UI
+
+Once the resource is added you can add the card directly through the
+"Add Card" dialog. Search for **Media Browser Card** and choose it to open
+the configuration dialog. From there you can set the title and the media
+player entity without editing YAML.
+
 ## Usage
 
 Add the following card configuration to your dashboard:

--- a/media-browser-card.js
+++ b/media-browser-card.js
@@ -115,3 +115,68 @@ class MediaBrowserCard extends HTMLElement {
   }
 }
 customElements.define("media-browser-card", MediaBrowserCard);
+
+MediaBrowserCard.getConfigElement = function () {
+  return document.createElement("media-browser-card-editor");
+};
+
+MediaBrowserCard.getStubConfig = function () {
+  return { title: "Media", entity: "browser" };
+};
+
+class MediaBrowserCardEditor extends HTMLElement {
+  setConfig(config) {
+    this._config = { ...config };
+    if (this._title) this._title.value = this._config.title || "";
+    if (this._entity) this._entity.value = this._config.entity || "browser";
+  }
+
+  connectedCallback() {
+    this.innerHTML = `
+      <style>
+        .card-config {
+          padding: 8px;
+        }
+        .card-config label {
+          display: block;
+          margin-bottom: 8px;
+        }
+      </style>
+      <div class="card-config">
+        <label>
+          Title
+          <input id="title" type="text" />
+        </label>
+        <label>
+          Entity
+          <input id="entity" type="text" placeholder="browser" />
+        </label>
+      </div>
+    `;
+    this._title = this.querySelector("#title");
+    this._entity = this.querySelector("#entity");
+    this._title.addEventListener("input", () => this._updateConfig());
+    this._entity.addEventListener("input", () => this._updateConfig());
+    if (this._config) {
+      this._title.value = this._config.title || "";
+      this._entity.value = this._config.entity || "browser";
+    }
+  }
+
+  _updateConfig() {
+    if (!this._config) this._config = {};
+    this._config.title = this._title.value;
+    this._config.entity = this._entity.value;
+    this.dispatchEvent(
+      new CustomEvent("config-changed", { detail: { config: this._config } })
+    );
+  }
+}
+customElements.define("media-browser-card-editor", MediaBrowserCardEditor);
+
+window.customCards = window.customCards || [];
+window.customCards.push({
+  type: "media-browser-card",
+  name: "Media Browser Card",
+  description: "Browse and play media from your library.",
+});


### PR DESCRIPTION
## Summary
- allow editing configuration from the UI by adding a custom editor
- register the card in `window.customCards`
- document how to add the card via UI

## Testing
- `node -c media-browser-card.js`

------
https://chatgpt.com/codex/tasks/task_e_68850be45c44832eb9db1bd1a8b3b39d