### PR TITLE
Allow hiding card header

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Once the resource is added you can add the card directly through the
 "Add Card" dialog. Search for **Media Browser Card** and choose it to open
 the configuration dialog. From there you can set the title and the media
 player entities without editing YAML. If the card does not show up in the
-list, reload the page so the resource is loaded.
+list, reload the page so the resource is loaded. Leave the title empty to
+hide the header completely.
 
 ## Usage
 

--- a/media-browser-card.js
+++ b/media-browser-card.js
@@ -7,7 +7,7 @@ class MediaBrowserCard extends HTMLElement {
 
   setConfig(config) {
     this._config = config || {};
-    this._title = this._config.title || "Media Browser";
+    this._title = this._config.title ?? "";
     this._entities = this._config.entities || [this._config.entity || "browser"];
     this._entity = this._entities[0];
     this._renderBase();
@@ -58,8 +58,9 @@ class MediaBrowserCard extends HTMLElement {
         margin: 0 8px;
       }
     `;
+    const headerAttr = this._title ? ` header="${this._title}"` : "";
     this.shadowRoot.innerHTML = `
-      <ha-card header="${this._title}">
+      <ha-card${headerAttr}>
         <div class="controls">
           <div class="back" hidden id="back">⬅ Back</div>
           <select id="entity-select" class="entity-select"></select>


### PR DESCRIPTION
## Summary
- allow empty titles and omit the `ha-card` header when no title is set
- document how to hide the header in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68851134f6e4832eaa520664ecf2a428